### PR TITLE
update grain immediately after mirror is in sync again

### DIFF
--- a/2018/002-update-channels.md
+++ b/2018/002-update-channels.md
@@ -125,6 +125,8 @@ The user interface of velum needs to be adapted minimally.
 * indirect display of new version content through a link to the release notes
 * button to switch to the next channel in velum
   - the button will trigger `transactional-update salt migrate`
+* confirmation of the user that the mirrors are synced
+  - this confirmation (button) will trigger the "new version" checker again to make sure the sync is done and grains are updated
 
 Velum needs to know when a new version is available, by looking at a special grain, that indicates
 the availability of a new version. This grain is set by the service that runs on each worker.
@@ -241,3 +243,4 @@ None known at the moment.
 | Date       | Comment       |
 |:-----------|:--------------|
 | 2018-07-31 | Initial Draft |
+| 2018-08-30 | Update for more mirror sync details |


### PR DESCRIPTION
otherwise velum will be left in an inconsistent state, and still
reports that the mirror is out of sync

Signed-off-by: Maximilian Meister <mmeister@suse.de>

@thkukuk this is a minor detail we need to consider, i am not sure how this can be achieved with the service, so i assigned you on this